### PR TITLE
Fix scapy version to 2.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-scapy
+scapy==2.4.0


### PR DESCRIPTION
Got exception with last pip scapy version 2.4.2

Fix version to stable release 2.4.0